### PR TITLE
Add /server_descriptions endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New feature(s):
 - Add `hw_virt` filter to `/servers` and `/server_prices`.
 - Add `network_speed_max_min`, `network_storage_speed_baseline_min` and `network_storage_speed_max_min` filters to `/servers`.
 - Update parameter titles and descriptions.
+- Add `/server_descriptions` endpoint for querying `ServerDescription` records by vendor and server ID.
 
 ‼ Breaking changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New feature(s):
 - Add `hw_virt` filter to `/servers` and `/server_prices`.
 - Add `network_speed_max_min`, `network_storage_speed_baseline_min` and `network_storage_speed_max_min` filters to `/servers`.
 - Update parameter titles and descriptions.
-- Add `/server/{vendor}/{server}/descriptions` endpoint for querying `ServerDescription` records of a single server.
+- Add `/server/{vendor}/{server}/descriptions` endpoint returning the `ServerDescription` of a single server.
 
 ‼ Breaking changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New feature(s):
 - Add `hw_virt` filter to `/servers` and `/server_prices`.
 - Add `network_speed_max_min`, `network_storage_speed_baseline_min` and `network_storage_speed_max_min` filters to `/servers`.
 - Update parameter titles and descriptions.
-- Add `/server_descriptions` endpoint for querying `ServerDescription` records by vendor and server ID.
+- Add `/server/{vendor}/{server}/descriptions` endpoint for querying `ServerDescription` records of a single server.
 
 ‼ Breaking changes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.6"
 requires-python = ">= 3.11"
 dependencies = [
   "safe-exit",
-  "sparecores-crawler>=0.6.0,<0.7",
+  "sparecores-crawler>=0.7.0,<0.8",
   "sparecores-data>=0.4.1",
   "fastapi==0.128.8",
   "uvicorn",

--- a/src/sc_keeper/api.py
+++ b/src/sc_keeper/api.py
@@ -18,6 +18,7 @@ from sc_crawler.tables import (
     Country,
     Region,
     Server,
+    ServerDescription,
     ServerPrice,
     Storage,
     StoragePrice,
@@ -116,6 +117,9 @@ example_data = {
     "region": db.exec(select(Region).where(Region.vendor_id == "aws").limit(1)).one(),
     "zone": db.exec(select(Zone).where(Zone.vendor_id == "aws").limit(1)).one(),
     "server": db.exec(select(Server).where(Server.vendor_id == "aws").limit(1)).one(),
+    "server_description": db.exec(
+        select(ServerDescription).where(ServerDescription.vendor_id == "aws").limit(1)
+    ).one(),
     "storage": db.exec(
         select(Storage).where(Storage.vendor_id == "aws").limit(1)
     ).one(),
@@ -151,6 +155,9 @@ Zone.model_config["json_schema_extra"] = {
 }
 Server.model_config["json_schema_extra"] = {
     "examples": [example_data["server"].model_dump()]
+}
+ServerDescription.model_config["json_schema_extra"] = {
+    "examples": [example_data["server_description"].model_dump()]
 }
 ServerPKs.model_config["json_schema_extra"] = Server.model_config["json_schema_extra"]
 ServerPKs.model_config["json_schema_extra"]["examples"][0]["score"] = 42

--- a/src/sc_keeper/api.py
+++ b/src/sc_keeper/api.py
@@ -18,6 +18,7 @@ from sc_crawler.tables import (
     Country,
     Region,
     Server,
+    ServerDescription,
     ServerPrice,
     Storage,
     StoragePrice,
@@ -1573,3 +1574,19 @@ def search_benchmark_configs(
         results[i] = result
 
     return sorted(results, key=get_sort_key_for_benchmark_configs)
+
+
+@app.get("/server_descriptions", tags=["Query Resources"])
+def search_server_descriptions(
+    partial_name_or_id: options.partial_name_or_id = None,
+    vendor: options.vendor = None,
+    db: Session = Depends(get_db),
+) -> List[ServerDescription]:
+    query = select(ServerDescription)
+    if partial_name_or_id:
+        ilike = "%" + partial_name_or_id + "%"
+        query = query.where(ServerDescription.server_id.ilike(ilike))
+    if vendor:
+        query = query.where(ServerDescription.vendor_id.in_(vendor))
+    results = db.exec(query).all()
+    return results

--- a/src/sc_keeper/api.py
+++ b/src/sc_keeper/api.py
@@ -18,7 +18,6 @@ from sc_crawler.tables import (
     Country,
     Region,
     Server,
-    ServerDescription,
     ServerPrice,
     Storage,
     StoragePrice,
@@ -1574,19 +1573,3 @@ def search_benchmark_configs(
         results[i] = result
 
     return sorted(results, key=get_sort_key_for_benchmark_configs)
-
-
-@app.get("/server_descriptions", tags=["Query Resources"])
-def search_server_descriptions(
-    partial_name_or_id: options.partial_name_or_id = None,
-    vendor: options.vendor = None,
-    db: Session = Depends(get_db),
-) -> List[ServerDescription]:
-    query = select(ServerDescription)
-    if partial_name_or_id:
-        ilike = "%" + partial_name_or_id + "%"
-        query = query.where(ServerDescription.server_id.ilike(ilike))
-    if vendor:
-        query = query.where(ServerDescription.vendor_id.in_(vendor))
-    results = db.exec(query).all()
-    return results

--- a/src/sc_keeper/routers/server.py
+++ b/src/sc_keeper/routers/server.py
@@ -14,6 +14,7 @@ from sc_crawler.tables import (
     BenchmarkScore,
     Region,
     Server,
+    ServerDescription,
     ServerPrice,
 )
 from sqlmodel import Session, and_, func, not_, select
@@ -439,3 +440,18 @@ def get_server_benchmarks(
         benchmarks.append(benchmark)
 
     return sorted(benchmarks, key=get_sort_key_for_benchmark_configs)
+
+
+@router.get("/server/{vendor}/{server}/descriptions")
+def get_server_descriptions(
+    server_args: options.server_args,
+    db: Session = Depends(get_db),
+) -> List[ServerDescription]:
+    """Query the descriptions of a single server."""
+    vendor_id, server_id = server_args
+
+    return db.exec(
+        select(ServerDescription)
+        .where(ServerDescription.vendor_id == vendor_id)
+        .where(ServerDescription.server_id == server_id)
+    ).all()

--- a/src/sc_keeper/routers/server.py
+++ b/src/sc_keeper/routers/server.py
@@ -450,8 +450,13 @@ def get_server_descriptions(
     """Query the descriptions of a single server."""
     vendor_id, server_id = server_args
 
-    return db.exec(
+    description = db.exec(
         select(ServerDescription)
         .where(ServerDescription.vendor_id == vendor_id)
         .where(ServerDescription.server_id == server_id)
-    ).all()
+    ).one_or_none()
+
+    if description is None:
+        raise HTTPException(status_code=404, detail="Server description not found")
+
+    return description

--- a/src/sc_keeper/routers/server.py
+++ b/src/sc_keeper/routers/server.py
@@ -446,7 +446,7 @@ def get_server_benchmarks(
 def get_server_descriptions(
     server_args: options.server_args,
     db: Session = Depends(get_db),
-) -> List[ServerDescription]:
+) -> ServerDescription:
     """Query the descriptions of a single server."""
     vendor_id, server_id = server_args
 


### PR DESCRIPTION
# Overview

Add `/server/{vendor}/{server}/descriptions` endpoint for querying `ServerDescription` records of a single server.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] New fields added to existing models are documented in the schemas and related examples added in `api.py`
- [ ] Major updates are also reflected in the `app.description` of `api.py`

Manual tests:

- [ ] General performance did not degrade
- [ ] OpenAPI/Swagger documentation renders correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoint `/server/{vendor}/{server}/descriptions` to retrieve server description details.

* **Chores**
  * Updated internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->